### PR TITLE
linking Code of Conduct from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,6 +5,7 @@
           <a href="http://www.mozillascience.org">
             <img src="img/ScienceLabSticker.ai.png" class="img-responsive img-centered" alt="">
           </a>
+          <a href="{{ site.github.repository_url }}/blob/gh-pages/codeOfConduct.md">Study Group Code of Conduct</a>
         </div>
       </div>
     </div>

--- a/codeOfConduct.md
+++ b/codeOfConduct.md
@@ -1,0 +1,25 @@
+# Code of Conduct
+
+Study Group events are community events intended for networking and collaboration as well as learning. We value the participation of every member of the scientific community and want all attendees to have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to show respect and courtesy to other attendees throughout the event and in interactions online associated with Study Group.
+
+To make clear what is expected, everyone taking part in Study Group events and discussions—instructors, helpers, organizers, and learners—is required to conform to the following Code of Conduct. Organizers will enforce this code throughout events, but you may also contact us privately; all communication will be treated as confidential.
+
+### The Short Version
+
+ - Study Group is dedicated to providing a harassment-free learning experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or choice of text editor. We do not tolerate harassment of participants in any form.
+ - All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate for any event.
+ - Be kind to others. Do not insult or put down other attendees.
+ - Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate.
+ - Attendees violating these rules may be asked to leave the event at the sole discretion of the event organizers without a refund of any charge that may have been levied.
+
+Thank you for helping make this a welcoming, friendly event for all.
+
+### The Longer Version
+
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you.
+
+If a participant engages in behavior that violates this code of conduct, the organizers may take any action they deem appropriate, including warning the offender or expulsion from the event with no refund of any fee that may have been levied.


### PR DESCRIPTION
Places a link to the Code of Conduct in the website footer. Text in `codeOfConduct.md` is the standard Mozilla Science CoC; feel free to change to suit your community after merge.
